### PR TITLE
Plugin support to package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ heroku config:add ETHERPAD_SETTINGS=settingsJSONinroot.json
 5. Add your Heroku app as a remote
 6. `git push heroku master`
 
+## plugin support
+
+Just add the plugin to package.json as a dependency.
+
+preparse.rb will copy all ep-starting packages to the etherpad plugins. Using the admin/plugins UI
+adds the plugin but it will reset in dyno restart
 
 ## additional settings
 

--- a/installPackages.sh
+++ b/installPackages.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+#Move to the folder where ep-lite is installed
+cd etherpad-lite
+
+echo "Copy all ep_* packages from the /app/node_modules to etherpad_lite/node_modules"
+echo "To install ep-plugins, add them to package.json"
+(
+  mkdir -p node_modules
+  cd node_modules
+  cp -R ../../node_modules/ep_* .
+) || {
+  exit 1
+}
+exit 0

--- a/preparse.rb
+++ b/preparse.rb
@@ -22,6 +22,8 @@ settings = {
 # Write the settings hash out as JSON.
 File.open('./etherpad-lite/settings.json', 'w') { |f| f.write(settings.to_json) }
 
+`./installPackages.sh`
+
 if ENV['ETHERPAD_ALLOW_ROOT'] == '1'
 exec('./etherpad-lite/bin/run.sh --root')
 else


### PR DESCRIPTION
Installs (copies) all ep_-starting packages from the root node_modules to the etherpad-lite/node_modules. 